### PR TITLE
Revert "Bump actions/checkout from 2.4.0 to 3"

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2.4.0
     - name: Build the site in the jekyll/builder container
       run: |
         docker run \


### PR DESCRIPTION
Reverts tudelft-cda-lab/tudelft-cda-lab.github.io#18